### PR TITLE
Mark-corrections[3,30,58,68,74,76,]

### DIFF
--- a/redstone-academy-docs/docs/pst/smartweave-in-browser/preparations.md
+++ b/redstone-academy-docs/docs/pst/smartweave-in-browser/preparations.md
@@ -1,6 +1,6 @@
 # Preparations
 
-To run your application just execute following command:
+To run your application just execute the following command:
 
 ```bash
 yarn serve
@@ -27,7 +27,7 @@ export const smartweave: SmartWeave =
   SmartWeaveWebFactory.memCachedBased(arweave).build();
 ```
 
-This time, we are using SDK's `SmartWeaveWebFactory` instead of `SmartWeaveNodeFactory` which will be safe to use in web environment.
+This time, we are using SDK's `SmartWeaveWebFactory` instead of `SmartWeaveNodeFactory` which will be safe to use in a web environment.
 Remember to export them as we will use them in a store for our app.
 
 ## 🆔 Indicating contract id
@@ -55,7 +55,7 @@ const contract = smartweave.pst(deployedContracts.fc).connect(wallet);
 
 ## ⛏️ Set the state of the contract
 
-You can get the state of your contract by destructuring the result of the PST method we already know - `currentState`. Thanks to having this object in the store, we will have constant access to current state of the contract and we will be able to display all the addresses and their balances.
+You can get the state of your contract by destructuring the result of the PST method we already know - `currentState`. Thanks to having this object in the store, we will have constant access to the current state of the contract and we will be able to display all the addresses and their balances.
 
 ```js
 const { state } = await contract.currentState();
@@ -65,15 +65,15 @@ That's it for the preparations! As you may notice, we used some things we've alr
 
 ## 🅰️ Preparing Arweave mainnet environment
 
-If you want to create an application which enables interacting with mainnet contract the only things you need to change in this section is indicating correct `host` in Arweave initialization (exactly like the last time - `arweave.net`) and pointing to the real wallet. This time it is best to detect if user has ArConnect already installed. If yes - `arweaveWallet` object will be available in `window` object and therefore you will be able to use ArConnect `connect` method. You can see its API in [ArConnect docs](https://docs.th8ta.org/arconnect/functions). You can also request necessary permissions. You can check list of available permissions [here](https://docs.th8ta.org/arconnect/permissions).
+If you want to create an application which enables interaction with the mainnet contract the only things you need to change in this section is indicating correct `host` in Arweave initialization (exactly like the last time - `arweave.net`) and pointing to the real wallet. This time it is best to detect if the user has ArConnect already installed. If yes - `arweaveWallet` object will be available in the `window` object and therefore you will be able to use ArConnect `connect` method. You can see its API in [ArConnect docs](https://docs.th8ta.org/arconnect/functions). You can also request necessary permissions. You can check a list of available permissions [here](https://docs.th8ta.org/arconnect/permissions).
 
 ```js
 await window.arweaveWallet.connect(['ACCESS_ADDRESS', 'SIGN_TRANSACTION']);
 ```
 
-This time we don't need generating wallet and funding it. Just remember that if the user of your app will want to interact with the contract, some AR tokens will be needed on his account.
+This time we don't need a generating wallet or to fund it. Just remember that if the user of your app wants to interact with the contract, some AR tokens will be needed on their account.
 
-After you connect user wallet to the application you will need to use `use_wallet` hook when initializing contract. It will connect contract to user's wallet. You can acheive that by writing following code:
+After you connect user wallet to the application you will need to use the `use_wallet` hook when initializing the contract. It will then connect the contract to the user's wallet. You can achieve this by writing following code:
 
 ```js
 const contract = smartweave.pst(deployedContracts.fc).connect('use_wallet`);


### PR DESCRIPTION
"To run your application just execute the following command:"
"This time, we are using SDK's `SmartWeaveWebFactory` instead of `SmartWeaveNodeFactory` which will be safe to use in a web environment."
"You can get the state of your contract by destructuring the result of the PST method we already know - `currentState`. Thanks to having this object in the store, we will have constant access to the current state of the contract and we will be able to display all the addresses and their balances."
"If you want to create an application which enables interaction with the mainnet contract the only things you need to change in this section is indicating correct `host` in Arweave initialization (exactly like the last time - `arweave.net`) and pointing to the real wallet. This time it is best to detect if the user has ArConnect already installed. If yes - `arweaveWallet` object will be available in the `window` object and therefore you will be able to use ArConnect `connect` method. You can see its API in [ArConnect docs](https://docs.th8ta.org/arconnect/functions). You can also request necessary permissions. You can check a list of available permissions [here](https://docs.th8ta.org/arconnect/permissions).
"After you connect user wallet to the application you will need to use the `use_wallet` hook when initializing the contract. It will then connect the contract to the user's wallet. You can achieve this by writing following code:"