### PR TITLE
Mark-corrections[5,9]

### DIFF
--- a/redstone-academy-docs/docs/pst/profit-sharing/profit-sharing-communities.md
+++ b/redstone-academy-docs/docs/pst/profit-sharing/profit-sharing-communities.md
@@ -2,11 +2,11 @@
 
 ## ❓ What are PSCs?
 
-Profit Sharing Community (PSC) are decentralised, open-sourced companies built on the Permaweb using SmartWeave contracts. Depending on how many of the community's PSTs a person holds and for how long a person wants to hold these tokens, the voting power is determined. It means that even small token holders can have power analogous to 'bigger fishes' (if they are for example willing to hold tokens for a long time).
+Profit Sharing Community (PSC) are decentralised and open-sourced companies built on the Permaweb using SmartWeave contracts. Depending on how many PSTs a person holds and for how long a person wants to hold these tokens, voting power is determined. This means that even small token holders can have power analogous to 'bigger fishes' (if they are for example willing to hold tokens for a long time).
 
 ## ✅ Benefits of PSCs
 
-Profit Sharing Communities provide more control for founders of the projects and at the same time assures contributors with more power. Thanks to PSCs contributors have fair governance rights, instant liquidity and of course revenue distributed to all the holder from the application usage
+Profit Sharing Communities provide more control for founders of projects whilst at the same time assure contributors with more power. Thanks to PSCs, contributors have fair governance rights, instant liquidity and of course revenue distributed to all holders from application usage.
 
 :::info
 In order to view or create PSC you can visit [community.xyz](https://community.xyz/home).


### PR DESCRIPTION
"Profit Sharing Community (PSC) are decentralised and open-sourced companies built on the Permaweb using SmartWeave contracts. Depending on how many PSTs a person holds and for how long a person wants to hold these tokens, voting power is determined. This means that even small token holders can have power analogous to 'bigger fishes' (if they are for example willing to hold tokens for a long time)".
"Profit Sharing Communities provide more control for founders of projects whilst at the same time assure contributors with more power. Thanks to PSCs, contributors have fair governance rights, instant liquidity and of course revenue distributed to all holders from application usage".